### PR TITLE
Issue 291: use ingestion time as product received time

### DIFF
--- a/accountability_api/api_utils/reporting/retrieval_time_report.py
+++ b/accountability_api/api_utils/reporting/retrieval_time_report.py
@@ -157,11 +157,9 @@ class RetrievalTimeReport(Report):
 
             for product in products:
                 # gather important timestamps for subsequent aggregations
-                if not product.get("hls"):  # possible in dev when skipping download job by direct file upload
-                    product_received_dt = datetime.fromisoformat(
-                        product["metadata"]["ProductReceivedTime"].removesuffix("Z"))
-                else:
-                    product_received_dt = datetime.fromisoformat(product["hls"]["download_datetime"].removesuffix("Z"))
+
+                product_received_dt = datetime.fromisoformat(
+                    product["metadata"]["ProductReceivedTime"].removesuffix("Z"))
                 product_received_ts = product_received_dt.timestamp()
                 current_app.logger.debug(f"{product_received_dt=!s}")
 

--- a/tests/unit/accountability_api/test_query.py
+++ b/tests/unit/accountability_api/test_query.py
@@ -166,11 +166,19 @@ def test_get_product_no_hits(mocker: MockerFixture, elasticsearch_no_hits):
 def test_get_num_docs_in_index(mocker: MockerFixture, elasticsearch_utility_stub):
     # ARRANGE
     mocker.patch("accountability_api.api_utils.query.es_connection.get_grq_es", return_value=elasticsearch_utility_stub)
-    mocker.patch.object(elasticsearch_utility_stub, "get_count", return_value=123)
+    mocker.patch.object(elasticsearch_utility_stub, "search", return_value={
+        "hits": {
+            "hits": [
+                {"_source": {"metadata": {}}},
+                {"_source": {"metadata": {}}},
+                {"_source": {"metadata": {}}}
+            ]
+        }
+    })
 
     # ACT
     # ASSERT
-    assert query.get_num_docs_in_index("*") == 123
+    assert query.get_num_docs_in_index("*") == 3
 
 
 def test_get_docs_in_index(mocker: MockerFixture, elasticsearch_index_non_empty):
@@ -187,10 +195,18 @@ def test_get_docs_in_index(mocker: MockerFixture, elasticsearch_index_non_empty)
 def test_get_num_docs(mocker: MockerFixture, elasticsearch_utility_stub):
     # ARRANGE
     mocker.patch("accountability_api.api_utils.query.es_connection.get_grq_es", return_value=elasticsearch_utility_stub)
-    mocker.patch.object(elasticsearch_utility_stub, "get_count", return_value=123)
+    mocker.patch.object(elasticsearch_utility_stub, "search", return_value={
+        "hits": {
+            "hits": [
+                {"_source": {"metadata": {}}},
+                {"_source": {"metadata": {}}},
+                {"_source": {"metadata": {}}}
+            ]
+        }
+    })
 
     # ACT
     index_alias_to_count = query.get_num_docs({"test_index_label": "test_index_name"})
 
     # ASSERT
-    assert index_alias_to_count["test_index_label"] == 123
+    assert index_alias_to_count["test_index_label"] == 3

--- a/tests/unit/accountability_api/v2/test_data.py
+++ b/tests/unit/accountability_api/v2/test_data.py
@@ -97,9 +97,7 @@ def test_ListDataTypeCounts_get_all(test_client: FlaskClient, mocker: MockerFixt
     # ASSERT
     get_docs_args = {
         "start": None,
-        "end": None,
-        "workflow_start": None,
-        "workflow_end": None
+        "end": None
     }
     get_num_docs_mock.assert_called_once_with({
         "HLS_L30": "grq_*_l2_hls_l30",
@@ -138,9 +136,7 @@ def test_ListDataTypeCounts_get_incoming(test_client: FlaskClient, mocker: Mocke
     # ASSERT
     get_docs_args = {
         "start": None,
-        "end": None,
-        "workflow_start": None,
-        "workflow_end": None
+        "end": None
     }
     get_num_docs_mock.assert_called_once_with({
         "HLS_L30": "grq_*_l2_hls_l30",
@@ -171,9 +167,7 @@ def test_ListDataTypeCounts_get_outgoing(test_client: FlaskClient, mocker: Mocke
     # ASSERT
     get_docs_args = {
         "start": None,
-        "end": None,
-        "workflow_start": None,
-        "workflow_end": None
+        "end": None
     }
     get_num_docs_mock.assert_called_once_with({
         "DSWX_HLS": "grq_*_l3_dswx_hls",


### PR DESCRIPTION
## Purpose
- change use of ingestion time as product received time for correctness
## Proposed Changes
- [CHANGE] use ingestion time as product received time
## Issues
- opera-sds-pcm #291
## Testing
- tested on dev cluster
