### PR TITLE
issue 28: feat(report): fix extremely slow histogram generation

### DIFF
--- a/accountability_api/api_utils/reporting/report_util.py
+++ b/accountability_api/api_utils/reporting/report_util.py
@@ -20,7 +20,7 @@ def create_histogram(*, series: list[float], title: str, metric: str, unit: str)
 
     fig = Figure(layout='tight')
     ax: Axes = fig.subplots()
-    ax.hist(series, bins=len(series))
+    ax.hist(series, bins='auto')
 
     xticks = [statistics.mean(series)]
 


### PR DESCRIPTION
Refs #28

## Purpose
- fix slow report generation
## Proposed Changes
- [FIX] slow report generation
## Issues
- see issue 28
## Testing
- Tested on dev cluster. Monthly report generation time is now 38 seconds instead of 28 minutes.
