### PR TITLE
fix(accountability): production time report support N/A edge cases

### DIFF
--- a/accountability_api/api_utils/reporting/production_time_report.py
+++ b/accountability_api/api_utils/reporting/production_time_report.py
@@ -131,8 +131,8 @@ class ProductionTimeReport(Report):
                     "opera_product_name": product["metadata"]["FileName"],
                     "opera_product_short_name": product["metadata"]["ProductType"],
                     "input_received_datetime": datetime.fromtimestamp(input_received_ts).isoformat(),
-                    "daac_alerted_datetime": datetime.fromtimestamp(daac_alerted_ts).isoformat() if daac_alerted_ts else daac_alerted_ts,
-                    "production_time": to_duration_isoformat(production_time_duration) if production_time_duration else production_time_duration
+                    "daac_alerted_datetime": datetime.fromtimestamp(daac_alerted_ts).isoformat() if daac_alerted_ts else "N/A",
+                    "production_time": to_duration_isoformat(production_time_duration) if production_time_duration else "N/A"
                 }
             elif report_type == "summary":
                 production_time_dict = {
@@ -167,21 +167,31 @@ class ProductionTimeReport(Report):
                 # ignore NULL production times for histogram generation
                 production_time_durations_hours = [t["production_time"] / 60 / 60 for t in production_times if t is not None and t["production_time"] is not None]
 
-                production_time_summary_row = {
-                    "opera_product_short_name": df_production_times_summary_row["opera_product_short_name"].iloc[0],
-                    "production_time_count": len(df_production_times_summary_row),
-                    "production_time_min": to_duration_isoformat(df_production_times_summary_row["production_time"].min()),
-                    "production_time_max": to_duration_isoformat(df_production_times_summary_row["production_time"].max()),
-                    "production_time_mean": to_duration_isoformat(df_production_times_summary_row["production_time"].mean()),
-                    "production_time_median": to_duration_isoformat(df_production_times_summary_row["production_time"].median())
-                }
-                if report_options["generate_histograms"]:
-                    histogram = create_histogram(
-                        series=production_time_durations_hours,
-                        title=f'{df_production_times_summary_row["opera_product_short_name"].iloc[0]} Production Times',
-                        metric="Production Time",
-                        unit="hours")
-                    production_time_summary_row.update({"histogram": str(base64.b64encode(histogram.getbuffer().tobytes()), "utf-8")})
+                if not len(df_production_times_summary_row): # EDGE CASE: no data for the product type / summary row
+                    production_time_summary_row = {
+                        "opera_product_short_name": product_type,
+                        "production_time_count": "N/A",
+                        "production_time_min": "N/A",
+                        "production_time_max": "N/A",
+                        "production_time_mean": "N/A",
+                        "production_time_median": "N/A"
+                    }
+                else:
+                    production_time_summary_row = {
+                        "opera_product_short_name": df_production_times_summary_row["opera_product_short_name"].iloc[0],
+                        "production_time_count": len(df_production_times_summary_row),
+                        "production_time_min": to_duration_isoformat(df_production_times_summary_row["production_time"].min()),
+                        "production_time_max": to_duration_isoformat(df_production_times_summary_row["production_time"].max()),
+                        "production_time_mean": to_duration_isoformat(df_production_times_summary_row["production_time"].mean()),
+                        "production_time_median": to_duration_isoformat(df_production_times_summary_row["production_time"].median())
+                    }
+                    if report_options["generate_histograms"]:
+                        histogram = create_histogram(
+                            series=production_time_durations_hours,
+                            title=f'{df_production_times_summary_row["opera_product_short_name"].iloc[0]} Production Times',
+                            metric="Production Time",
+                            unit="hours")
+                        production_time_summary_row.update({"histogram": str(base64.b64encode(histogram.getbuffer().tobytes()), "utf-8")})
 
                 production_time_summary_rows.append(production_time_summary_row)
             df_production_times_summary = pd.DataFrame(production_time_summary_rows)


### PR DESCRIPTION
Refs #770

## Purpose
- fix accoutability handling of edge case with NO production times for a given product type (happens when delivery is disabled in some environments)
## Proposed Changes
- [FIX] produciton time report generation
## Issues
- issue-770
## Testing
- tested on local dev environment against int-pop1 db
